### PR TITLE
Don't read property of null

### DIFF
--- a/redsess.js
+++ b/redsess.js
@@ -98,7 +98,7 @@ RedSess.prototype.get = function (k, cb) {
 
   this.getAll(function (er, all) {
     if (er) return cb(er)
-    all = all[k] || null
+    all = (all || {})[k] || null
     return cb(null, all)
   }.bind(this))
 }


### PR DESCRIPTION
When no session data is set, trying to get a value causes this exception:

```
TypeError: Cannot read property 'profile' of null
    at RedSess.<anonymous> (/Users/eivindfjeldstad/node/test/node_modules/redsess/redsess.js:101:14)
    at RedSess.<anonymous> (/Users/eivindfjeldstad/node/test/node_modules/redsess/redsess.js:112:12)
    at try_callback (/Users/eivindfjeldstad/node/test/node_modules/redis/index.js:484:9)
    at RedisClient.return_reply (/Users/eivindfjeldstad/node/test/node_modules/redis/index.js:555:13)
    at RedisReplyParser.<anonymous> (/Users/eivindfjeldstad/node/test/node_modules/redis/index.js:256:14)
    at RedisReplyParser.emit (events.js:87:17)
    at RedisReplyParser.send_reply (/Users/eivindfjeldstad/node/test/node_modules/redis/lib/parser/javascript.js:281:18)
    at RedisReplyParser.execute (/Users/eivindfjeldstad/node/test/node_modules/redis/lib/parser/javascript.js:166:26)
    at RedisClient.on_data (/Users/eivindfjeldstad/node/test/node_modules/redis/index.js:440:27)
    at Socket.<anonymous> (/Users/eivindfjeldstad/node/test/node_modules/redis/index.js:70:14)
```
