### PR TITLE
cookieOptions for passing options to cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ http.createServer(function (req, res) {
   you can do so.
 * `cookies` If you already have a Cookies object, you may pass that
   in.  If not specified, then it'll make a new one for you.
+* `cookieOptions` an object that extends the options object that is passed to 
+  `cookies.set` and `cookies.get`
 
 ## Methods
 

--- a/redsess.js
+++ b/redsess.js
@@ -4,6 +4,7 @@ var redis = require("redis")
 RedSess.client = null
 
 var Cookies = require('cookies')
+var util = require('util')
 
 // optional dependency
 try { var KeyGrip = require('keygrip') } catch (e) {}
@@ -41,7 +42,11 @@ function RedSess (req, res, opt) {
   // set the s-cookie
   var name = this.cookieName = opt.cookieName || 's'
   var expireDate = new Date(Date.now() + (this.expire*1000))
-  var copt = { expires: expireDate, signed: !!this.keys }
+  var cookieOptions = opt && opt.cookieOptions || {}
+  var copt = util._extend({
+    expires: expireDate,
+    signed: !!this.keys
+  }, cookieOptions)
 
   var s = this.cookies.get(name, copt)
   if (!s)
@@ -198,4 +203,7 @@ function unflatten (obj) {
 
   })
   return into
+
 }
+
+

--- a/test/basic.js
+++ b/test/basic.js
@@ -34,6 +34,11 @@ tap.test('setup', function (t) {
     console.error('SERVER', req.url)
     req.cookies = res.cookies = new Cookies(req, res)
     req.session = res.session = new RedSess(req, res)
+    var session = new RedSess(req, res, {
+      cookieOptions: {
+        path: "/cookie"
+      }
+    })
 
     res.send = function (n) {
       res.writeHead(200)
@@ -102,6 +107,12 @@ tap.test('setup', function (t) {
           if (er) throw er;
           res.send(JSON.stringify(
             { ok: true, destroyed: true }))
+        })
+
+      case '/cookie':
+        return session.set('str', 'str', function (er) {
+          if (er) throw er
+          res.send()
         })
 
       default:
@@ -280,9 +291,10 @@ tap.test('/del/all', function (t) {
 // now delete our session and start over
 tap.test('/destroy', function (t) {
   req('/destroy', function (er, res, data) {
-    var c = jar.cookies[0]
+    var c = jar.cookies[1]
     t.ok(c)
     t.equal(c.name, 's', 'cookie name')
+    t.equal(c.path, '/', 'cookie path')
     t.equal(c.value, '', 'destroyed cookie value')
     t.ok(c.httpOnly)
     t.type(c.expires, Date)
@@ -309,6 +321,18 @@ tap.test('re-establish session', function (t) {
     t.ok(c.httpOnly)
     t.type(c.expires, Date)
     t.ok(c.expires.getTime() > Date.now() + 60*1000)
+
+    t.end()
+  })
+})
+
+
+tap.test('/cookie', function (t) {
+  req('/cookie', function (er, res, data) {
+    var cookie = res.headers['set-cookie'][1]
+
+    t.ok(cookie.indexOf("/cookie") > -1)
+
     t.end()
   })
 })

--- a/test/redis.conf
+++ b/test/redis.conf
@@ -11,7 +11,6 @@ databases 16
 save 900 1
 save 300 10
 save 60 10000
-rdbcompression yes
 dbfilename dump.rdb
 dir /usr/local/var/db/redis/
 slave-serve-stale-data yes
@@ -22,14 +21,6 @@ auto-aof-rewrite-percentage 100
 auto-aof-rewrite-min-size 64mb
 slowlog-log-slower-than 10000
 slowlog-max-len 1024
-vm-enabled no
-vm-swap-file /tmp/redis.swap
-vm-max-memory 0
-vm-page-size 32
-vm-pages 134217728
-vm-max-threads 4
-hash-max-zipmap-entries 512
-hash-max-zipmap-value 64
 list-max-ziplist-entries 512
 list-max-ziplist-value 64
 set-max-intset-entries 512


### PR DESCRIPTION
`cookies` has get/set methods which take options, in our use case we need to pass `options.domain` to cookies.set

this patch exposes those options via redsess. another solution is to patch cookies and then pass this patched cookies instance to redsess:

https://github.com/jed/cookies/pull/17
