### PR TITLE
Use Generic Session for all session handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,7 @@ Deletes a key from the session.
 * session.del(cb)
 
 Deletes the entire session.
+
+## Generic Session
+
+**redsess** uses [Generic Session](https://github.com/rvagg/node-generic-session) for session handling, see that project for more detailed documentation on the functionality available to session users.

--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
   "main": "redsess.js",
   "dependencies": {
     "redis": "~0.8.1",
-    "cookies": "~0.3.2"
-  },
-  "optionalDependencies": {
-    "keygrip": "~0.2.2"
+    "generic-session": "~0.0.0"
   },
   "engines": {
     "node": ">=0.7.7"


### PR DESCRIPTION
For your consideration.

See https://github.com/rvagg/node-generic-session

In this PR, all session handling is handled by Generic Session, the main role for redsess is to handle the redis interaction.

An alternative approach would be to just export a Generic Session compatible Store (i.e. RedStore) and allow the user to piece the two together but that would break the existing API so I've left the external API pretty much the same--I haven't touched the tests at all so you can see it's the same on the outside.

Defaults and `options` properties are the same as redsess. If this PR looks worthwhile then I'll give you commit access to Generic Session so you can tinker in there too if you feel the need.
