### PR TITLE
Add optional custom session token

### DIFF
--- a/redsess.js
+++ b/redsess.js
@@ -53,7 +53,7 @@ function RedSess (req, res, opt) {
 
   var s = this.cookies.get(name, copt)
   if (!s)
-    s = require('crypto').randomBytes(30).toString('base64')
+    s = opt.token || require('crypto').randomBytes(30).toString('base64')
 
   this.cookies.set(name, s, copt)
   this.token = s


### PR DESCRIPTION
This is a PR that allows for a custom session token. Currently, there is no way to use anything except for node's `crypto` module for generating a user's session token.

My use case is that during security evaluation, we felt more comfortable with using an already vetted source (e.g. `/dev/urandom`) for generating our random bytes.
